### PR TITLE
Awaitable Interface

### DIFF
--- a/include/rev/api/alg/drive/turn/campbell_turn.hh
+++ b/include/rev/api/alg/drive/turn/campbell_turn.hh
@@ -3,6 +3,7 @@
 #include <memory>
 #include "rev/api/alg/drive/turn/turn.hh"
 #include "rev/api/alg/odometry/odometry.hh"
+#include "rev/api/async/async_awaitable.hh"
 #include "rev/api/async/async_runnable.hh"
 #include "rev/api/hardware/chassis/chassis.hh"  // For chassis model
 
@@ -13,7 +14,8 @@ namespace rev {
  *
  */
 class CampbellTurn : public Turn,
-                     public AsyncRunnable {  // Rename this if you want
+                     public AsyncRunnable,
+                     public AsyncAwaitable {  // Rename this if you want
  public:
   CampbellTurn(std::shared_ptr<Chassis> ichassis,
                std::shared_ptr<Odometry> iodometry,
@@ -33,6 +35,12 @@ class CampbellTurn : public Turn,
    *
    */
   void step() override;
+
+  /**
+   * @brief Blocks until the current turn completes
+   *
+   */
+  void await() override;
 
   /**
    * @brief Tells if the controller is working or has completed its motion

--- a/include/rev/api/alg/reckless/reckless.hh
+++ b/include/rev/api/alg/reckless/reckless.hh
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "rev/api/alg/reckless/path.hh"
+#include "rev/api/async/async_awaitable.hh"
 #include "rev/api/async/async_runnable.hh"
 #include "rev/api/hardware/chassis/chassis.hh"
 
@@ -14,7 +15,7 @@ enum class RecklessStatus { ACTIVE, DONE };
  * @brief High-speed chassis motion controller
  *
  */
-class Reckless : public AsyncRunnable {
+class Reckless : public AsyncRunnable, public AsyncAwaitable {
  public:
   Reckless(std::shared_ptr<Chassis> ichassis,
            std::shared_ptr<Odometry> odometry);
@@ -23,6 +24,12 @@ class Reckless : public AsyncRunnable {
    * controller logic is
    */
   void step() override;
+
+  /**
+   * @brief Blocks until the motion is completed
+   *
+   */
+  void await() override;
 
   /**
    * This function starts the robot along a path

--- a/include/rev/api/async/async_awaitable.hh
+++ b/include/rev/api/async/async_awaitable.hh
@@ -12,6 +12,6 @@ class AsyncAwaitable {
    *
    */
   virtual void await() = 0;
-}
+};
 
 }  // namespace rev

--- a/include/rev/api/async/async_awaitable.hh
+++ b/include/rev/api/async/async_awaitable.hh
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace rev {
+/**
+ * @brief Interface for classes which have something that can be waited for
+ *
+ */
+class AsyncAwaitable {
+ public:
+  /**
+   * @brief Blocking method which returns when the awaited event has occured
+   *
+   */
+  virtual void await() = 0;
+}
+
+}  // namespace rev

--- a/src/api/alg/drive/turn/campbell_turn.cc
+++ b/src/api/alg/drive/turn/campbell_turn.cc
@@ -142,6 +142,11 @@ void CampbellTurn::step() {
 }
 // You will need implementations for every method
 
+void CampbellTurn::await() {
+  while (!is_completed())
+    pros::delay(10);
+}
+
 bool CampbellTurn::is_completed() {
   return (controller_state == TurnState::INACTIVE);
 }

--- a/src/api/alg/reckless/reckless.cc
+++ b/src/api/alg/reckless/reckless.cc
@@ -124,6 +124,13 @@ void Reckless::step() {
       (double)current_segment + current_segment_progress.convert(number);
 }
 
+void Reckless::await() {
+  // Technically we can make this lighter with a condition variable or semaphore
+  // but its not worth it in this case because its a very quick check
+  while (!is_completed())
+    pros::delay(10);
+}
+
 /**
  * This function starts the robot along a path
  */


### PR DESCRIPTION
This feature just adds methods to the asynchronous features of ReveilLib that have defined targets, so you can wait for them to complete their job.